### PR TITLE
Various Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ new IsolatedExternalsPlugin({
 });
 ```
 
+`entryName`, in this instance, is the name of one of your webpack [Entry Points](https://webpack.js.org/concepts/entry-points/).
+
 The external files will be loaded and applied to your context in the order that they're listed, so if you have dependencies that depend on other dependencies (like `ReactDOM` depends on `React`), then you'll want to make sure you list the ones they depend on first.
 
 ## How It Works

--- a/src/IsolatedExternalsPlugin.ts
+++ b/src/IsolatedExternalsPlugin.ts
@@ -47,7 +47,10 @@ function wrapApp(
 ): ConcatSource {
   const externalsList = Object.entries(externals);
   const varNames = externalsList
-    .map(([, external]) => `var ${external.name} = context.${external.name};`)
+    .map(
+      ([, external]) =>
+        `var ${external.name} = context.${external.name} || ( window || global || self )["${external.name}"];`
+    )
     .join(' ');
   const wrappedSource = new ConcatSource(
     `function ${appName}(context){`,

--- a/src/IsolatedExternalsPlugin.ts
+++ b/src/IsolatedExternalsPlugin.ts
@@ -51,8 +51,11 @@ function wrapApp(
     .join(' ');
   const wrappedSource = new ConcatSource(
     `function ${appName}(context){`,
+    `\n`,
     varNames,
+    `\n`,
     source,
+    `\n`,
     `}`
   );
   return wrappedSource;
@@ -63,7 +66,7 @@ async function addLoadExternals(
 ): Promise<ConcatSource> {
   const externalsLocation = path.resolve(__dirname, 'util', 'loadExternals.js');
   const loadExternals = await readFile(externalsLocation);
-  return new ConcatSource(source, loadExternals.toString());
+  return new ConcatSource(source, `\n`, loadExternals.toString());
 }
 
 function callLoadExternals(
@@ -79,7 +82,7 @@ function callLoadExternals(
 }
 
 function selfInvoke(source: Source | string): ConcatSource {
-  return new ConcatSource(`(function() {`, source, `})()`);
+  return new ConcatSource(`(function() {`, source, `})();`);
 }
 
 function getConfigExternals(

--- a/src/IsolatedExternalsPlugin.ts
+++ b/src/IsolatedExternalsPlugin.ts
@@ -160,7 +160,9 @@ function getTargetAssets(
 export default class IsolatedExternalsPlugin {
   appName: string;
   constructor(readonly config: IsolatedExternalsConfig = {}) {
-    this.appName = randomstring.generate(12);
+    this.appName =
+      randomstring.generate({ length: 1, charset: 'alphabetic' }) +
+      randomstring.generate(11);
   }
 
   apply(compiler: Compiler): void {


### PR DESCRIPTION
* Ensuring we don't start our random function name with a number
* Ensuring dependencies finish loading in the correct order
* Adding line breaks to account for source map comments
* Falling back to a global variable if one does not exist on the local context
* Adding some better documentation around what `entryName` is in the README