### PR TITLE
Update: continue loading externals after eval failure

### DIFF
--- a/src/util/loadExternals.ts
+++ b/src/util/loadExternals.ts
@@ -107,7 +107,12 @@ function loadExternals(
       if (failed) {
         console.error(`failed to load external from '${url}'`);
       } else {
-        wrappedEval.call(context, content);
+        try {
+          wrappedEval.call(context, content);
+        }
+        catch (e) {
+          console.error(`failed to eval external from ${url}`, e);
+        }
       }
 
       const nextIndex = index + 1;


### PR DESCRIPTION
It happens sometimes that when isolated externals are loaded eval'ng one of them fails. Unfortunately I can't tell from the stack trace which external caused it. This change should make it clear. Also it will continue to execute code if it fails which is not happening right now (similarly to when network load fails).