### PR TITLE
Fix: falling back to xhr when fetch fails

### DIFF
--- a/src/util/loadExternals.ts
+++ b/src/util/loadExternals.ts
@@ -66,10 +66,6 @@ function XHRLoad(
 
 async function fetchLoad(external: CachedExternal): Promise<CachedExternal> {
   const response = await fetch(external.url, {
-    headers: {
-      'Content-Type': 'text/javascript',
-    },
-
     // "follow" is technically the default,
     // but making epxlicit for backwards compatibility
     redirect: 'follow',
@@ -85,8 +81,12 @@ async function networkLoad(
   onLoaded: (loadedExternal: CachedExternal) => void
 ): Promise<void> {
   if ({}.hasOwnProperty.call(window, 'fetch')) {
-    const loadedExternal = await fetchLoad(external);
-    onLoaded(loadedExternal);
+    try {
+      const loadedExternal = await fetchLoad(external);
+      onLoaded(loadedExternal);
+    } catch {
+      XHRLoad(external, onLoaded);
+    }
   } else {
     XHRLoad(external, onLoaded);
   }


### PR DESCRIPTION
We were seeing some failures in pre-flight requests to unpkg, which caused CORS errors. This fallback will work even if that happens.

Also removed extra headers—they were causing preloads to fail because of mismatched requests.